### PR TITLE
feat(apache): support check license header with RAT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,11 @@ jobs:
         with:
           fetch-depth: 2
 
+      - name: License check(RAT)
+        run: |
+          mvn apache-rat:check | grep -v "Downloading\|Downloaded\|Progress"
+          find ./ -name rat.txt -print0 | xargs -0 -I file cat file > merged-rat.txt && cat merged-rat.txt
+
       - name: Compile
         run: |
           mvn compile -Dmaven.javadoc.skip=true | grep -v "Downloading\|Downloaded"

--- a/hugegraph-common/build.sh
+++ b/hugegraph-common/build.sh
@@ -1,4 +1,20 @@
 #!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 export MAVEN_HOME=/home/scmtools/buildkit/maven/apache-maven-3.3.9/
 export JAVA_HOME=/home/scmtools/buildkit/java/jdk1.8.0_25/

--- a/hugegraph-common/pom.xml
+++ b/hugegraph-common/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -11,7 +27,7 @@
     </parent>
 
     <artifactId>hugegraph-common</artifactId>
-    <name>${artifactId}</name>
+    <name>${project.artifactId}</name>
     <url>https://github.com/apache/incubator-hugegraph-commons/tree/master/hugegraph-common</url>
     <description>
         hugegraph-common is a common module for HugeGraph and its peripheral components.

--- a/hugegraph-common/pom.xml
+++ b/hugegraph-common/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>hugegraph-common</artifactId>
-    <name>${project.artifactId}</name>
+    <name>${artifactId}</name>
     <url>https://github.com/apache/incubator-hugegraph-commons/tree/master/hugegraph-common</url>
     <description>
         hugegraph-common is a common module for HugeGraph and its peripheral components.

--- a/hugegraph-common/src/test/java/org/apache/hugegraph/unit/concurrent/BarrierEventTest.java
+++ b/hugegraph-common/src/test/java/org/apache/hugegraph/unit/concurrent/BarrierEventTest.java
@@ -32,7 +32,7 @@ import org.apache.hugegraph.testutil.Assert;
 
 public class BarrierEventTest {
     
-    private static final int WAIT_THREADS_COUNT = 10;
+    private static int WAIT_THREADS_COUNT = 10;
 
     @Test(timeout = 5000)
     public void testAWait() throws InterruptedException {

--- a/hugegraph-common/src/test/java/org/apache/hugegraph/unit/concurrent/BarrierEventTest.java
+++ b/hugegraph-common/src/test/java/org/apache/hugegraph/unit/concurrent/BarrierEventTest.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2017 HugeGraph Authors
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.hugegraph.unit.concurrent;
 
 import java.util.concurrent.CountDownLatch;
@@ -13,7 +32,7 @@ import org.apache.hugegraph.testutil.Assert;
 
 public class BarrierEventTest {
     
-    private static int WAIT_THREADS_COUNT = 10;
+    private static final int WAIT_THREADS_COUNT = 10;
 
     @Test(timeout = 5000)
     public void testAWait() throws InterruptedException {

--- a/hugegraph-common/src/test/resources/log4j2.xml
+++ b/hugegraph-common/src/test/resources/log4j2.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
 <configuration status="error">
     <appenders>
         <Console name="console" target="SYSTEM_OUT">

--- a/hugegraph-rpc/pom.xml
+++ b/hugegraph-rpc/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>hugegraph-rpc</artifactId>
-    <name>${project.artifactId}</name>
+    <name>${artifactId}</name>
     <description>HugeGraph RPC component</description>
 
     <properties>

--- a/hugegraph-rpc/pom.xml
+++ b/hugegraph-rpc/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -11,7 +27,7 @@
     </parent>
 
     <artifactId>hugegraph-rpc</artifactId>
-    <name>${artifactId}</name>
+    <name>${project.artifactId}</name>
     <description>HugeGraph RPC component</description>
 
     <properties>

--- a/hugegraph-rpc/src/test/resources/log4j2.xml
+++ b/hugegraph-rpc/src/test/resources/log4j2.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
 <configuration status="error">
     <appenders>
         <Console name="console" target="SYSTEM_OUT">

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -18,9 +34,9 @@
     </description>
 
     <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
+        <groupId>org.apache</groupId>
+        <artifactId>apache</artifactId>
+        <version>23</version>
     </parent>
 
     <licenses>
@@ -163,6 +179,43 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <!-- Apache RAT for license check -->
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*.versionsBackup</exclude>
+                        <exclude>**/*.log</exclude>
+                        <exclude>**/*.txt</exclude>
+                        <exclude>**/*.json</exclude>
+                        <exclude>**/*.conf</exclude>
+                        <exclude>**/*.properties</exclude>
+                        <exclude>dist/**/*</exclude>
+                        <exclude>docs/**/*</exclude>
+                        <exclude>scripts/dev/reviewers</exclude>
+                        <exclude>**/*.md</exclude>
+                        <exclude>**/dependency-reduced-pom.xml</exclude>
+                        <exclude>**/logs/*.log</exclude>
+                        <exclude>**/target/*</exclude>
+                        <exclude>style/*</exclude>
+                        <exclude>ChangeLog</exclude>
+                        <exclude>CONFIG.ini</exclude>
+                        <exclude>GROUPS</exclude>
+                        <exclude>OWNERS</exclude>
+                        <!-- GitHub -->
+                        <exclude>.github/**/*</exclude>
+                        <!-- Intellij -->
+                        <exclude>**/*.iml</exclude>
+                        <exclude>**/*.iws</exclude>
+                        <exclude>**/*.ipr</exclude>
+                        <exclude>**/META-INF/MANIFEST.MF</exclude>
+                        <!-- Maven -->
+                        <exclude>.repository/**</exclude>
+                    </excludes>
+                    <consoleOutput>true</consoleOutput>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
use `mvn apache-rat:check` to see the report, and use `find ./ -name rat.txt -print0 | xargs -0 -I file cat file > merged-rat.txt` to merge all modules' check file

and fix current license problems

TODO: we should add & use apache-rat plugin in other repos later

BTW, we'd reuse such configs better (rather than copy them in each repo)