### PR TITLE
chore: prepare for release v1.0.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,5 @@
 .gitignore export-ignore
 .asf.yaml export-ignore
 apache-release.sh export-ignore
+
+hugegraph-dist/scripts export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# ignore when package to source.tgz
+.github/ export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.asf.yaml export-ignore
+apache-release.sh export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -29,10 +29,10 @@ build
 ### NetBeans ###
 /nbproject/private/
 /nbbuild/
-/dist/
 /nbdist/
 /.nb-gradle/
 build/
+dist/
 
 ### VS Code ###
 .vscode/
@@ -61,7 +61,7 @@ output/
 *.war
 *.zip
 *.tar
-*.tar.gz
+*.tar.gz*
 tree.txt
 *.versionsBackup
 

--- a/hugegraph-common/build.sh
+++ b/hugegraph-common/build.sh
@@ -21,4 +21,3 @@ export JAVA_HOME=/home/scmtools/buildkit/java/jdk1.8.0_25/
 export PATH=$JAVA_HOME/bin:$MAVEN_HOME/bin:$PATH
 
 mvn clean test -Dtest=UnitTestSuite
-

--- a/hugegraph-dist/scripts/apache-release.sh
+++ b/hugegraph-dist/scripts/apache-release.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+GROUP="hugegraph"
+# current REPOsitory name
+REPO="${GROUP}-commons"
+# release version (input by committer)
+RELEASE_VERSION=$1
+# git release branch (check it carefully)
+GIT_BRANCH="release-${RELEASE_VERSION}"
+
+RELEASE_VERSION=${RELEASE_VERSION:?"Please input the release version behind script"}
+
+WORK_DIR=$(cd "$(dirname "$0")" || exit; pwd)
+cd "${WORK_DIR}" || exit
+echo "In the work dir: $(pwd)"
+
+# clean old dir then build a new one
+rm -rfv dist && mkdir -p dist/apache-${REPO}
+
+# step1: package the source code
+git archive --format=tar.gz \
+  --output="dist/apache-${REPO}/apache-${REPO}-incubating-${RELEASE_VERSION}-src.tar.gz" \
+  --prefix=apache-${REPO}-incubating-"${RELEASE_VERSION}"-src/ "${GIT_BRANCH}" || exit
+
+# step2: copy the binary file (Optional)
+# Note: it's optional for project to generate binary package (skip this step if not need)
+#cp -v ../../target/apache-${REPO}-incubating-"${RELEASE_VERSION}".tar.gz \
+#  dist/apache-${REPO} || exit
+
+# step3: sign + hash
+##### 3.1 sign in source & binary package
+gpg --version 1>/dev/null || exit
+cd ./dist/apache-${REPO} || exit
+for i in *.tar.gz; do
+  echo "$i" && gpg --armor --output "$i".asc --detach-sig "$i"
+done
+
+##### 3.2 Generate SHA512 file
+shasum --version 1>/dev/null || exit
+for i in *.tar.gz; do
+  echo "$i" && shasum -a 512 "$i" >"$i".sha512
+done
+
+#### 3.3 check signature & sha512
+for i in *.tar.gz; do
+  echo "$i"
+  gpg --verify "$i".asc "$i" || exit
+done
+
+for i in *.tar.gz; do
+  echo "$i"
+  shasum -a 512 --check "$i".sha512 || exit
+done
+
+# step4: upload to Apache-SVN
+SVN_DIR="${GROUP}-svn-dev"
+cd ../
+rm -rfv ${SVN_DIR}
+
+svn co "https://dist.apache.org/repos/dist/dev/incubator/${GROUP}" ${SVN_DIR}
+mkdir -p ${SVN_DIR}/"${RELEASE_VERSION}"
+cp -v apache-${REPO}/*tar.gz* "${SVN_DIR}/${RELEASE_VERSION}"
+cd ${SVN_DIR} || exit
+
+# check status first
+svn status
+svn add "${RELEASE_VERSION}"
+# check status again
+svn status
+# commit & push files
+svn commit -m "submit files for ${REPO} ${RELEASE_VERSION}"
+
+echo "Finished all, please check all steps in script manually again! "

--- a/hugegraph-dist/scripts/dependency/check_dependencies.sh
+++ b/hugegraph-dist/scripts/dependency/check_dependencies.sh
@@ -16,16 +16,16 @@
 # limitations under the License.
 #
 
-BASE_PATH=$(cd $(dirname $0); pwd)
+BASE_PATH=$(cd "$(dirname "$0")" || exit; pwd)
 
 # check whether there are new third-party dependencies by diff command,
 # diff generated 'current-dependencies.txt' file with 'known-dependencies.txt' file.
-diff -w -B -U0 <(sort < ${BASE_PATH}/known-dependencies.txt) \
-<(sort < ${BASE_PATH}/current-dependencies.txt) > ${BASE_PATH}/result.txt
+diff -w -B -U0 <(sort < "${BASE_PATH}"/known-dependencies.txt) \
+  <(sort < "${BASE_PATH}"/current-dependencies.txt) > "${BASE_PATH}"/result.txt
 
 # if has new third-party,the Action will fail and print diff
-if [ -s ${BASE_PATH}/result.txt ]; then
-  cat ${BASE_PATH}/result.txt
+if [ -s "${BASE_PATH}"/result.txt ]; then
+  cat "${BASE_PATH}"/result.txt
   exit 1
 else
   echo 'All third dependencies is known!'

--- a/hugegraph-dist/scripts/dependency/regenerate_known_dependencies.sh
+++ b/hugegraph-dist/scripts/dependency/regenerate_known_dependencies.sh
@@ -16,18 +16,18 @@
 # limitations under the License.
 #
 
-BASE_PATH=$(cd $(dirname $0); pwd)
+BASE_PATH=$(cd "$(dirname "$0")" || exit; pwd)
 DEP_PATH=$BASE_PATH/all_dependencies
 FILE_NAME=${1:-known-dependencies.txt}
 
-if [[ -d $DEP_PATH ]];then
+if [[ -d $DEP_PATH ]]; then
   echo "rm -r -f DEP_PATH"
-  rm -r -f $DEP_PATH
+  rm -r -f "$DEP_PATH"
 fi
 
-cd $BASE_PATH/../../../
+cd "$BASE_PATH"/../../../ || exit
 
-mvn dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=$DEP_PATH
+mvn dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory="$DEP_PATH"
 
-ls $DEP_PATH | egrep -v "^hugegraph|hubble" | sort -n > $BASE_PATH/$FILE_NAME
-rm -r -f $DEP_PATH
+ls "$DEP_PATH" | egrep -v "^hugegraph|hubble" | sort -n > "$BASE_PATH"/"$FILE_NAME"
+rm -r -f "$DEP_PATH"


### PR DESCRIPTION
we could use git command to generate source file directly (and exclude some files by `.gitattr`)

`git archive --format=tar.gz --output=dist/apache-hugegraph-commons/apache-hugegraph-commons-1.0.0-incubating-src.tar.gz --prefix=apache-hugegraph-commons-1.0.0-incubating-src/ release-1.0.0`

and I try to unify the release steps by one script, it should be test first