### PR TITLE
Update 'How to Contribute' link and remove duplicate 'Guidelines'  link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ And here are links of other repositories:
 
 ## Contributing
 
-- Welcome to contribute to HugeGraph, please see [How to Contribute](https://github.com/apache/incubator-hugegraph/blob/master/CONTRIBUTING.md) for more information.  
+- Welcome to contribute to HugeGraph, please see [How to Contribute](https://hugegraph.apache.org/docs/contribution-guidelines/contribute/) for more information.  
 - Note: It's recommended to use [GitHub Desktop](https://desktop.github.com/) to greatly simplify the PR and commit process.  
 - Thank you to all the people who already contributed to HugeGraph!
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ And here are links of other repositories:
 
 ## Contributing
 
-- Welcome to contribute to HugeGraph, please see [`How to Contribute`](CONTRIBUTING.md) & [Guidelines](https://hugegraph.apache.org/docs/contribution-guidelines/) for more information.  
+- Welcome to contribute to HugeGraph, please see [How to Contribute](https://github.com/apache/incubator-hugegraph/blob/master/CONTRIBUTING.md) for more information.  
 - Note: It's recommended to use [GitHub Desktop](https://desktop.github.com/) to greatly simplify the PR and commit process.  
 - Thank you to all the people who already contributed to HugeGraph!
 


### PR DESCRIPTION
This PR makes the following changes to the README file to streamline the contribution guidelines and avoid redundancy:

- Updated the 'How to Contribute' link to ensure it directs contributors to the correct resource.
- Removed the 'Guidelines' link as it duplicated the information provided in 'How to Contribute'.